### PR TITLE
Fix crash on refreshing in All Courses

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AllCourseFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AllCourseFragment.kt
@@ -27,6 +27,7 @@ import org.jetbrains.anko.AnkoContext
 import org.jetbrains.anko.AnkoLogger
 import org.jetbrains.anko.support.v4.ctx
 import kotlin.concurrent.thread
+import org.jetbrains.anko.support.v4.runOnUiThread
 
 
 class AllCourseFragment : Fragment(), AnkoLogger {
@@ -173,7 +174,9 @@ class AllCourseFragment : Fragment(), AnkoLogger {
                         courseDao.insert(course)
                         runDao.insert(courseRun)
                         if (ui.swipeRefreshLayout.isRefreshing) {
-                            ui.swipeRefreshLayout.isRefreshing = false
+                            runOnUiThread {
+                                ui.swipeRefreshLayout.isRefreshing = false
+                            }
                         }
                         //Add CourseInstructors
                         for (i in myCourses.instructors!!) {


### PR DESCRIPTION
Fixes #171 

Changes:

Now, app would not crash on reloading in All Courses.

GIF for the change:

![ezgif com-video-to-gif (74)](https://user-images.githubusercontent.com/35566748/57863639-11852f00-7818-11e9-9961-443cdc887c03.gif)