### PR TITLE
Fix Swipe to Refresh

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/fragments/MyCoursesFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/fragments/MyCoursesFragment.kt
@@ -20,6 +20,7 @@ import com.codingblocks.cbonlineapp.viewmodels.HomeViewModel
 import com.ethanhua.skeleton.Skeleton
 import com.ethanhua.skeleton.SkeletonScreen
 import com.google.firebase.analytics.FirebaseAnalytics
+import kotlinx.android.synthetic.main.fragment_course_content.*
 import org.jetbrains.anko.AnkoContext
 import org.jetbrains.anko.AnkoLogger
 import org.jetbrains.anko.support.v4.ctx
@@ -89,6 +90,7 @@ class MyCoursesFragment : Fragment(), AnkoLogger {
             viewModel.progress.value = true
             skeletonScreen.show()
             viewModel.fetchMyCourses()
+            displayCourses()
         }
 
         viewModel.progress.observer(viewLifecycleOwner) {


### PR DESCRIPTION
Fixes 
Added a **displayCourses()** line after fetchingCourses in setOnRefreshListener

Changes: Previously: On swiping it just kept on refreshing with skeletonScreen
Now: On Refreshing it displays course content

Screenshots for the change:
![Refresh](https://user-images.githubusercontent.com/29565914/57953755-8885fa80-78e0-11e9-914c-2f2f5010a0b0.gif)

