### PR TITLE
Improvement in Previous Attempts leaderboard.

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/adapters/QuizAttemptListAdapter.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/adapters/QuizAttemptListAdapter.kt
@@ -1,7 +1,5 @@
 package com.codingblocks.cbonlineapp.adapters
 
-import android.graphics.Color
-import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,25 +8,22 @@ import androidx.recyclerview.widget.RecyclerView
 import com.codingblocks.cbonlineapp.R
 import com.codingblocks.cbonlineapp.extensions.formatDate
 import com.codingblocks.onlineapi.models.QuizAttempt
+import kotlinx.android.synthetic.main.quiz_attempt_list.view.*
 
-class QuizAttemptListAdapter(private val dataset: ArrayList<QuizAttempt>) :
+class QuizAttemptListAdapter(val dataset: ArrayList<QuizAttempt>, val clickListner : (QuizAttempt) -> Unit) :
     RecyclerView.Adapter<QuizAttemptListAdapter.QuizAttemptViewHolder>() {
 
-    var onItemClick: ((QuizAttempt)->Unit) ?= null
-
-    inner class QuizAttemptViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
-        var numberTextView: TextView? = null
-        var dateTextView: TextView? = null
-        var scoreTextView: TextView? = null
-        var statusTextView: TextView? = null
-
-        init {
-            numberTextView = view.findViewById(R.id.numberTv)
-            dateTextView = view.findViewById(R.id.dateTv)
-            scoreTextView = view.findViewById(R.id.scoreTv)
-            statusTextView = view.findViewById(R.id.statusTv)
+    class QuizAttemptViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+        fun bind(attempt : QuizAttempt, clickListner : (QuizAttempt) -> Unit) {
+            view.numberTv.text = (adapterPosition + 1).toString()
+            view.statusTv.text = attempt.status
+            view.dateTv.text = formatDate(attempt.createdAt!!)
+            if (attempt.result?.score != null)
+                view.scoreTv.text = attempt.result?.score.toString()
+            else
+                view.scoreTv.text = "N/A"
             view.setOnClickListener {
-                onItemClick?.invoke(dataset[adapterPosition])
+                clickListner(attempt)
             }
         }
     }
@@ -42,14 +37,7 @@ class QuizAttemptListAdapter(private val dataset: ArrayList<QuizAttempt>) :
 
     // Replace the contents of view
     override fun onBindViewHolder(holder: QuizAttemptViewHolder, position: Int) {
-        val currentAttempt = dataset[position]
-        holder.numberTextView?.text = (position + 1).toString()
-        holder.statusTextView?.text = currentAttempt.status
-        holder.dateTextView?.text = formatDate(currentAttempt.createdAt!!)
-        if (currentAttempt.result?.score != null)
-            holder.scoreTextView?.text = currentAttempt.result?.score.toString()
-        else
-            holder.scoreTextView?.text = "N/A"
+        holder.bind(dataset[position], clickListner)
     }
 
     // return size of the current data

--- a/app/src/main/java/com/codingblocks/cbonlineapp/adapters/QuizAttemptListAdapter.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/adapters/QuizAttemptListAdapter.kt
@@ -1,67 +1,57 @@
 package com.codingblocks.cbonlineapp.adapters
 
-import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ArrayAdapter
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import com.codingblocks.cbonlineapp.R
-import com.codingblocks.cbonlineapp.util.OnItemClickListener
 import com.codingblocks.cbonlineapp.extensions.formatDate
 import com.codingblocks.onlineapi.models.QuizAttempt
-import org.jetbrains.anko.AnkoLogger
-import java.util.*
 
-class QuizAttemptListAdapter(internal var context: Context,
-                             var list: ArrayList<QuizAttempt>?,
-                             var listener: OnItemClickListener
-) : ArrayAdapter<QuizAttempt>(context, 0), AnkoLogger {
+class QuizAttemptListAdapter(private val dataset: ArrayList<QuizAttempt>) :
+    RecyclerView.Adapter<QuizAttemptListAdapter.QuizAttemptViewHolder>() {
 
-    override fun getCount(): Int {
-        return if (list == null) 0 else list!!.size
-    }
+    var onItemClick: ((QuizAttempt)->Unit) ?= null
 
-    override fun getItem(i: Int): QuizAttempt? {
-        return list!![i]
-    }
+    inner class QuizAttemptViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+        var numberTextView: TextView? = null
+        var dateTextView: TextView? = null
+        var scoreTextView: TextView? = null
+        var statusTextView: TextView? = null
 
-    override fun getItemId(i: Int): Long {
-        return i.toLong()
-    }
-
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-        var view = convertView
-        if (view == null) {
-            view = LayoutInflater.from(context).inflate(R.layout.quiz_attempt_list, parent, false)
-
-            val pos = view!!.findViewById<TextView>(R.id.numberTv)
-            val status = view.findViewById<TextView>(R.id.statusTv)
-            val time = view.findViewById<TextView>(R.id.dateTv)
-            val score = view.findViewById<TextView>(R.id.scoreTv)
-
-            val attemptViewHolder = AttemptViewHolder(pos, status, time, score)
-            view.tag = attemptViewHolder
+        init {
+            numberTextView = view.findViewById(R.id.numberTv)
+            dateTextView = view.findViewById(R.id.dateTv)
+            scoreTextView = view.findViewById(R.id.scoreTv)
+            statusTextView = view.findViewById(R.id.statusTv)
+            view.setOnClickListener {
+                onItemClick?.invoke(dataset[adapterPosition])
+            }
         }
-        val e = getItem(position)//to differentiate between filtered list and todo list
-        val attemptViewHolder = view.tag as AttemptViewHolder
-        attemptViewHolder.posTextView.text = (position + 1).toString() + ""
-        attemptViewHolder.statusTextView.text = e?.status!!
-        attemptViewHolder.timeTextView.text =
-            formatDate(e.createdAt!!)
-
-        if (e.result?.score != null) {
-            attemptViewHolder.scoreTextView.text = e.result?.score.toString()
-        } else {
-            attemptViewHolder.scoreTextView.text = "N/A"
-
-        }
-        view.setOnClickListener {
-            listener.onItemClick(position, e.id!!)
-        }
-
-        return view
     }
 
-    class AttemptViewHolder(var posTextView: TextView, var statusTextView: TextView, var timeTextView: TextView, var scoreTextView: TextView)
+    // Create new views
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuizAttemptViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.quiz_attempt_list, parent, false)
+        return QuizAttemptViewHolder(view)
+    }
+
+    // Replace the contents of view
+    override fun onBindViewHolder(holder: QuizAttemptViewHolder, position: Int) {
+        val currentAttempt = dataset[position]
+        holder.numberTextView?.text = (position + 1).toString()
+        holder.statusTextView?.text = currentAttempt.status
+        holder.dateTextView?.text = formatDate(currentAttempt.createdAt!!)
+        if (currentAttempt.result?.score != null)
+            holder.scoreTextView?.text = currentAttempt.result?.score.toString()
+        else
+            holder.scoreTextView?.text = "N/A"
+    }
+
+    // return size of the current data
+    override fun getItemCount() = dataset.size
 }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/extensions/LiveDataExtensions.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/extensions/LiveDataExtensions.kt
@@ -106,7 +106,7 @@ fun formatDate(date: String): String {
     calender.time = newDate
     calender.add(Calendar.HOUR, 5)
     calender.add(Calendar.MINUTE, 30)
-    format = SimpleDateFormat("MMM dd,yyyy hh:mm", Locale.US)
+    format = SimpleDateFormat("MMM dd yyyy\nhh:mm a", Locale.US)
     return format.format(calender.time)
 }
 

--- a/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AboutQuizFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AboutQuizFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.codingblocks.cbonlineapp.R
 import com.codingblocks.cbonlineapp.adapters.QuizAttemptListAdapter
 import com.codingblocks.cbonlineapp.extensions.retrofitCallback
@@ -53,12 +54,7 @@ class AboutQuizFragment : Fragment(), AnkoLogger {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? = inflater.inflate(R.layout.fragment_about_quiz, container, false).apply {
-        quizAttemptListAdapter =
-            QuizAttemptListAdapter(context, attemptList, object : OnItemClickListener {
-                override fun onItemClick(position: Int, id: String) {
-                    initiateQuiz(id)
-                }
-            })
+        quizAttemptListAdapter = QuizAttemptListAdapter(attemptList)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -76,11 +72,16 @@ class AboutQuizFragment : Fragment(), AnkoLogger {
             qnaId = it.getString(QUIZ_QNA)
         }
 
-        val header =
-            layoutInflater.inflate(R.layout.quiz_attempt_header, quizAttemptLv, false) as ViewGroup
-        quizAttemptLv.addHeaderView(header, null, false)
-        quizAttemptLv.adapter = quizAttemptListAdapter
+        val viewManager = LinearLayoutManager(context)
+        quizAttemptLv.apply {
+            setHasFixedSize(true)
+            layoutManager = viewManager
+            adapter = quizAttemptListAdapter
+        }
 
+        quizAttemptListAdapter.onItemClick = { it ->
+            initiateQuiz(it.id)
+        }
 
         fetchQuizDetails()
         fetchQuizAttempts()

--- a/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AboutQuizFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/fragments/AboutQuizFragment.kt
@@ -54,7 +54,9 @@ class AboutQuizFragment : Fragment(), AnkoLogger {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? = inflater.inflate(R.layout.fragment_about_quiz, container, false).apply {
-        quizAttemptListAdapter = QuizAttemptListAdapter(attemptList)
+        quizAttemptListAdapter = QuizAttemptListAdapter(attemptList) { attempt : QuizAttempt ->
+            initiateQuiz(attempt.id)
+        }
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -77,10 +79,6 @@ class AboutQuizFragment : Fragment(), AnkoLogger {
             setHasFixedSize(true)
             layoutManager = viewManager
             adapter = quizAttemptListAdapter
-        }
-
-        quizAttemptListAdapter.onItemClick = { it ->
-            initiateQuiz(it.id)
         }
 
         fetchQuizDetails()

--- a/app/src/main/res/layout/fragment_about_quiz.xml
+++ b/app/src/main/res/layout/fragment_about_quiz.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/aboutQuiz"
     android:layout_width="match_parent"
@@ -142,14 +143,73 @@
         android:textColor="@color/black"
         android:textSize="22sp" />
 
-    <ListView
-        android:id="@+id/quizAttemptLv"
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="12dp"
-        tools:listitem="@layout/quiz_attempt_list" />
+        android:layout_marginBottom="8dp"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="4dp">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:id="@+id/quiz_attempt_list_head"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:orientation="horizontal"
+                android:paddingTop="10dp"
+                android:paddingBottom="10dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="0.8"
+                    android:gravity="center"
+                    android:text="S.No."
+                    android:textColor="@color/black" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1.4"
+                    android:text="Attempt Time"
+                    android:textColor="@color/black" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="0.8"
+                    android:gravity="center"
+                    android:text="Score"
+                    android:textColor="@color/black" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="Action"
+                    android:textColor="@color/black" />
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/quizAttemptLv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/quiz_attempt_list_head"
+                tools:listitem="@layout/quiz_attempt_list" />
+        </RelativeLayout>
+    </androidx.cardview.widget.CardView>
 
 
 </LinearLayout>


### PR DESCRIPTION
Fixes part 3 of #181 

Changes: 1. Previous attempts leaderboard is now the same as on the website.
2. Replaced ListView with RecyclerView for better performance.

Screenshots for the change:
![Screenshot_1558480227](https://user-images.githubusercontent.com/34043056/58136606-4a743800-7c4c-11e9-9c17-9b2f683b5296.png)
