### PR TITLE
fix: Video Player now maintains the ratio, neverless the device ratio

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/activities/VideoPlayerActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/activities/VideoPlayerActivity.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import android.widget.RelativeLayout
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.codingblocks.cbonlineapp.BuildConfig
@@ -35,7 +36,6 @@ import com.vdocipher.aegis.media.ErrorDescription
 import com.vdocipher.aegis.media.Track
 import com.vdocipher.aegis.player.VdoPlayer
 import com.vdocipher.aegis.player.VdoPlayer.PlayerHost.VIDEO_STRETCH_MODE_MAINTAIN_ASPECT_RATIO
-import com.vdocipher.aegis.player.VdoPlayer.PlayerHost.VIDEO_STRETCH_MODE_STRETCH_TO_FIT
 import com.vdocipher.aegis.player.VdoPlayerFragment
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import kotlinx.android.synthetic.main.activity_video_player.displayYoutubeVideo
@@ -108,10 +108,7 @@ class VideoPlayerActivity : AppCompatActivity(),
             displayYoutubeVideo.view?.visibility = View.GONE
             videoContainer.visibility = View.VISIBLE
             playerFragment = fragmentManager.findFragmentById(R.id.videoView) as VdoPlayerFragment
-            val metrics = resources.displayMetrics
-            val ratio = (metrics.heightPixels.toFloat() - 100) / (metrics.widthPixels.toFloat() - 100)
-            playerFragment.setAspectRatio(ratio)
-//            playerFragment.videoStretchMode = VIDEO_STRETCH_MODE_STRETCH_TO_FIT
+            playerFragment.videoStretchMode = VIDEO_STRETCH_MODE_MAINTAIN_ASPECT_RATIO
             playerControlView = findViewById(R.id.player_control_view)
             showControls(false)
 
@@ -345,7 +342,6 @@ class VideoPlayerActivity : AppCompatActivity(),
             )
             // go to landscape orientation for fullscreen mode
             ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-
         } else {
             window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
             // go to portrait orientation
@@ -365,7 +361,6 @@ class VideoPlayerActivity : AppCompatActivity(),
             window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
         }
     }
-
 
     private val playbackListener = object : VdoPlayer.PlaybackEventListener {
         override fun onTracksChanged(p0: Array<out Track>?, p1: Array<out Track>?) {
@@ -430,6 +425,13 @@ class VideoPlayerActivity : AppCompatActivity(),
                 player_tabs.visibility = View.GONE
                 pagerFrame.visibility = View.GONE
                 playerControlView?.fitsSystemWindows = true
+
+                val paramsFragment: RelativeLayout.LayoutParams = playerFragment.view?.layoutParams as RelativeLayout.LayoutParams
+                paramsFragment.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+                paramsFragment.addRule(RelativeLayout.ALIGN_PARENT_TOP)
+                paramsFragment.addRule(RelativeLayout.ALIGN_PARENT_START)
+                paramsFragment.addRule(RelativeLayout.ALIGN_PARENT_END)
+
                 // hide system windows
                 showControls(false)
             }
@@ -439,6 +441,13 @@ class VideoPlayerActivity : AppCompatActivity(),
                 pagerFrame.visibility = View.VISIBLE
 
                 playerControlView?.fitsSystemWindows = false
+
+                val paramsFragment: RelativeLayout.LayoutParams = playerFragment.view?.layoutParams as RelativeLayout.LayoutParams
+                paramsFragment.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+                paramsFragment.removeRule(RelativeLayout.ALIGN_PARENT_TOP)
+                paramsFragment.removeRule(RelativeLayout.ALIGN_PARENT_START)
+                paramsFragment.removeRule(RelativeLayout.ALIGN_PARENT_END)
+
                 playerControlView?.setPadding(0, 0, 0, 0)
                 // show system windows
             }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/viewmodels/HomeViewModel.kt
@@ -168,7 +168,7 @@ class HomeViewModel(
                                                             updatedAt,
                                                             progress,
                                                             course?.title ?: "",
-                                                            summary = course?.summary?: "",
+                                                            summary = course?.summary ?: "",
                                                             premium = runAttempts?.get(0)?.premium
                                                                 ?: false
                                                         )


### PR DESCRIPTION
Fixes #267 

Changes:
- the fragment adjusts itself to the parent when rotated

Screenshots for the change:
https://drive.google.com/open?id=1-C3szqVQunoyQqjZ3yT7qfuqE9OQV27V