### PR TITLE
fix: null pointer exception in pdf activity

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/activities/PdfActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/activities/PdfActivity.kt
@@ -109,16 +109,18 @@ class PdfActivity : AppCompatActivity(), AnkoLogger {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (MediaUtils.checkPermission(this)) {
             try {
-                if (pdfViewPager.adapter != null)
-                    (pdfViewPager.adapter as PDFPagerAdapter).close()
+                val adapter = pdfViewPager.adapter
+                if (adapter is PDFPagerAdapter)
+                    adapter.close()
+                pdfViewPager.adapter = null
             } catch (e: Exception) {
                 onBackPressed()
             }
         } else {
         }
         this@PdfActivity.unregisterReceiver(receiver)
+        super.onDestroy()
     }
 }


### PR DESCRIPTION
Fixes #311

Changes:
- destroy the fragment and adapter first, then move on to destroying the activity
