### PR TITLE
fix: add connection pool that does'nt keep failed sockets

### DIFF
--- a/onlineapi/src/main/kotlin/com/codingblocks/onlineapi/Clients.kt
+++ b/onlineapi/src/main/kotlin/com/codingblocks/onlineapi/Clients.kt
@@ -15,6 +15,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ConnectionPool
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.jackson.JacksonConverterFactory
@@ -69,6 +70,7 @@ object Clients {
     private val ClientInterceptor = OkHttpClient.Builder()
         .connectTimeout(connectTimeout.toLong(), TimeUnit.SECONDS)
         .readTimeout(readTimeout.toLong(), TimeUnit.SECONDS)
+        .connectionPool(ConnectionPool(0, 1, TimeUnit.NANOSECONDS))
         .addInterceptor { chain ->
             chain.proceed(
                 chain.request().newBuilder().addHeader(


### PR DESCRIPTION
Fixes #284 

Changes: 
- Added ConnectionPool that will drop the failed sockets and retry connection hence handle the socket timeout
