### PR TITLE
Rename debug app suffix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ android {
         debug {
             minifyEnabled false
             versionNameSuffix '-debug-version'
-            applicationIdSuffix = 'debug'
+            applicationIdSuffix = '.debug'
 
         }
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ spotless {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.android.material:material:1.1.0-alpha10'
+    implementation 'com.google.android.material:material:1.1.0-beta01'
 
     // Android Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
@@ -113,7 +113,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'com.google.android.play:core:1.6.3'
     implementation 'androidx.core:core-ktx:1.1.0'
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha05"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-beta01"
     implementation "androidx.paging:paging-runtime-ktx:2.1.0"
     implementation "android.arch.work:work-runtime-ktx:1.0.1"
     implementation "androidx.fragment:fragment-ktx:1.1.0"
@@ -134,7 +134,7 @@ dependencies {
     implementation 'com.caverock:androidsvg-aar:1.4'
 
     //database
-    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-runtime:2.2.0"
     kapt "androidx.room:room-compiler:$room_version"
 
 


### PR DESCRIPTION
Changes: Application suffix id from 'debug' to '.debug' (the right way)