### PR TITLE
fixes text out of bounds in about instructor section

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/insturctors/InstructorListUi.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/insturctors/InstructorListUi.kt
@@ -75,7 +75,6 @@ class InstructorListUi : AnkoComponent<ViewGroup> {
                 textColor = Color.parseColor("#000000")
                 textSize = 14f
             }.lparams(width = dip(0), height = dip(wrapContent)) {
-                marginStart = dip(16)
                 topMargin = dip(8)
                 marginEnd = dip(8)
                 topToBottom = instructorImgView.id


### PR DESCRIPTION
Fixes #425 

Changes: Adjusted the layout margin of the description text view.

Screenshots for the change:

<img src = "https://user-images.githubusercontent.com/31350501/66834672-b9478a00-ef7b-11e9-8fc4-70a94eade0e4.jpg" width = 300>
