### PR TITLE
Fixed toll-free number spacing issue which caused it to overflow sing…

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -52,7 +52,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
-                android:letterSpacing="0.5"
+                android:letterSpacing="0.25"
                 android:text="@string/tollfree_number"
                 android:textAlignment="center"
                 android:textColor="@color/black"


### PR DESCRIPTION

Changes: changed the letter spacing for toll free number which caused contact number overflow in contact us activity (activity_about.xml).

Screenshots for the change:

Before:
![Screenshot_20191023-225235](https://user-images.githubusercontent.com/25999879/67420847-fe5b6400-f5ec-11e9-8338-2b6d98ddd62d.png)

After:
![Screenshot_20191023-231812](https://user-images.githubusercontent.com/25999879/67420869-0c10e980-f5ed-11e9-845f-6706229489a6.png)

