### PR TITLE
Updated/Removed OutOfBound Errors with low space android/Added function easy for storage retreival/share

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,7 +126,19 @@
             android:parentActivityName=".mycourse.MyCourseActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppThemeMain" />
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.codingblocks.cbonlineapp"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
         <receiver android:name=".util.DownloadBroadcastReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<path xmlns:android="http://schemas.android.com/apk/res/android">
+<external-path name="external_files" path="."/>
+</path> 


### PR DESCRIPTION
Removed Memory Out Of bound Errors with low space android:
      java.lang.OutOfMemoryError: Failed to allocate a  byte allocation

Solved Android 9 issue:
    https://developer.android.com/about/versions/pie/android-9.0-changes-28
    Android 9 (API level 28) introduces a number of changes to the Android system. The following 
    behavior changes apply exclusively to apps that are targeting API level 28 or higher. Apps that set 
    targetSdkVersion to API level 28 or higher must modify their apps to support these behaviors 
    properly, where applicable to the app.