### PR TITLE
Added Empty View in Notes Tab

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/player/notes/VideoNotesFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/player/notes/VideoNotesFragment.kt
@@ -76,13 +76,30 @@ class VideoNotesFragment : BaseCBFragment(), AnkoLogger {
         playerNotesRv.setRv(requireContext(), notesListAdapter, false)
 
         viewModel.notes.observer(viewLifecycleOwner) {
-            notesListAdapter.submitList(it)
+            if (it.isNullOrEmpty()) {
+                notesListAdapter.submitList(emptyList())
+                showEmptyView(false)
+            } else {
+                notesListAdapter.submitList(it)
+                showEmptyView(true)
+            }
+
         }
 
         notesListAdapter.apply {
             onDeleteClick = deleteClickListener
             onEditClick = editClickListener
             onItemClick = itemClickListener
+        }
+    }
+
+    private fun showEmptyView(show: Boolean) {
+        if (show) {
+            playerNotesRv.visibility = View.VISIBLE
+            noNotesLayout.visibility = View.GONE
+        } else {
+            playerNotesRv.visibility = View.GONE
+            noNotesLayout.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/player/notes/VideoNotesFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/player/notes/VideoNotesFragment.kt
@@ -76,14 +76,8 @@ class VideoNotesFragment : BaseCBFragment(), AnkoLogger {
         playerNotesRv.setRv(requireContext(), notesListAdapter, false)
 
         viewModel.notes.observer(viewLifecycleOwner) {
-            if (it.isNullOrEmpty()) {
-                notesListAdapter.submitList(emptyList())
-                showEmptyView(false)
-            } else {
-                notesListAdapter.submitList(it)
-                showEmptyView(true)
-            }
-
+            notesListAdapter.submitList(it)
+            showEmptyView(it.isNullOrEmpty())
         }
 
         notesListAdapter.apply {
@@ -94,13 +88,8 @@ class VideoNotesFragment : BaseCBFragment(), AnkoLogger {
     }
 
     private fun showEmptyView(show: Boolean) {
-        if (show) {
-            playerNotesRv.visibility = View.VISIBLE
-            noNotesLayout.visibility = View.GONE
-        } else {
-            playerNotesRv.visibility = View.GONE
-            noNotesLayout.visibility = View.VISIBLE
-        }
+        playerNotesRv.isVisible = !show
+        noNotesLayout.isVisible = show
     }
 
     override fun onDestroy() {

--- a/app/src/main/res/layout/fragment_notes.xml
+++ b/app/src/main/res/layout/fragment_notes.xml
@@ -1,9 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
     android:id="@+id/videoNotesRoot"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/noNotesLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:visibility="gone"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/libEmptyImg"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_note_big" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:fontFamily="@font/gilroy_bold"
+            android:text="No Notes"
+            android:textAlignment="center"
+            android:textColor="@color/orangish"
+            android:textSize="18sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_small"
+            android:fontFamily="@font/gilroy_bold"
+            android:text="Click on + to add a new note."
+            android:textAlignment="center"
+            android:textColor="@color/dark_white"
+            android:textSize="14sp" />
+
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/playerNotesRv"

--- a/app/src/main/res/layout/fragment_notes.xml
+++ b/app/src/main/res/layout/fragment_notes.xml
@@ -26,7 +26,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium"
             android:fontFamily="@font/gilroy_bold"
-            android:text="No Notes"
+            android:text="@string/no_notes"
             android:textAlignment="center"
             android:textColor="@color/orangish"
             android:textSize="18sp" />
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_small"
             android:fontFamily="@font/gilroy_bold"
-            android:text="Click on + to add a new note."
+            android:text="@string/click_on_to_add_a_new_note"
             android:textAlignment="center"
             android:textColor="@color/dark_white"
             android:textSize="14sp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,4 +284,6 @@
     <string name="progress" >%d %%</string>
     <string name="completed" >%d %% Completed</string>
     <string name="continue_from_where_you_left">Continue from where you left</string>
+    <string name="no_notes">No Notes</string>
+    <string name="click_on_to_add_a_new_note">Click on + to add a new note.</string>
 </resources>


### PR DESCRIPTION
Fixes #662 
Changes: Added a Linearlayout which contains empty view of notes icon, title and sub text of it

Screenshots for the change:
![vlcsnap-2020-05-11-10h13m05s221](https://user-images.githubusercontent.com/32957484/81524883-7cf0d680-9370-11ea-963c-81f35fe8b3fa.png)