### PR TITLE
fixes referral button text getting cropped

### DIFF
--- a/app/src/main/res/layout/activity_referral.xml
+++ b/app/src/main/res/layout/activity_referral.xml
@@ -198,7 +198,7 @@
             android:id="@+id/shareWhatsapp"
             android:fontFamily="@font/gilroy_bold"
             android:textColor="@color/white"
-            android:textSize="14sp"
+            android:textSize="12sp"
             android:text="@string/share_via_whatsapp"
             app:cornerRadius="30dp" />
 
@@ -215,7 +215,7 @@
             android:id="@+id/shareReferral"
             android:text="@string/more"
             android:textColor="@color/black"
-            android:textSize="14sp"
+            android:textSize="12sp"
             app:icon="@drawable/ic_share"
             app:iconPadding="10dp"
             app:iconTint="@color/black"


### PR DESCRIPTION
Fixes #687

Changes:  changed size of buttons to `12sp` . Now it isn't getting cut on my phone anymore, but i think a better solution would be to add a horizontal scroller for buttons. let me know if i should add that in place of current approach

Screenshots for the change:

![image](https://user-images.githubusercontent.com/31290636/81883483-f8da6100-95b2-11ea-9523-53af7a21fc6f.png)

