### PR TITLE
OTP Button is not overlapping with the otp edit text view and able to…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
         <activity
             android:name=".auth.LoginActivity"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize|adjustPan" />
         <activity android:name=".auth.onboarding.OnBoardingActivity" />
         <activity
             android:name=".dashboard.ChatActivity"


### PR DESCRIPTION
Fixes #668 

Changes: 
OTP Button is not overlapping with the otp edit text view and able to view and type properly

Screenshots for the change:
![WhatsApp Image 2020-05-15 at 09 08 30](https://user-images.githubusercontent.com/32957484/82009019-d23c2900-968b-11ea-8c0d-dae5c2774a1d.jpeg)
