### PR TITLE
set Max value to Set Download Limit seekbar

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
@@ -71,7 +71,7 @@ class SettingsActivity : BaseCBActivity() {
                 }
             )
         }
-
+        setSeekbarMaxValue()
         seekbarLimit.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 if (fromUser)
@@ -108,5 +108,11 @@ class SettingsActivity : BaseCBActivity() {
         val size = (1 + progress / 100.toDouble()).toFloat()
         seekbarTv.text = "${size}GB"
         getPrefs().SP_DATA_LIMIT = size
+    }
+
+    private fun setSeekbarMaxValue(){
+        val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+        val progressValue = (100*bytesAvailable/Math.pow(1024.0,3.0)).toInt()-100
+        seekbarLimit.max=progressValue
     }
 }


### PR DESCRIPTION
Fixes #713 

Changes: 
Added a function which will` set max value` to the `Set Download Limit seekbar` in Settings Activity based on the available storage

Screenshots for the change:

![WhatsApp Image 2020-05-15 at 6 41 32 PM](https://user-images.githubusercontent.com/29014716/82053937-c8421680-96db-11ea-9858-d8d804c7ee15.jpeg)

