### PR TITLE
Fix: #676 Title bar name change according to tab

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/dashboard/DashboardActivity.kt
@@ -338,13 +338,13 @@ class DashboardActivity : BaseCBActivity(),
 
             R.id.dashboard_explore -> changeToolbar(getString(R.string.welcome), 0)
 
-            R.id.dashboard_courses -> changeToolbar(getString(R.string.dashboard), 1)
+            R.id.dashboard_courses -> changeToolbar(getString(R.string.my_courses), 1)
 
             R.id.dashboard_home -> changeToolbar(getString(R.string.dashboard), 2)
 
-            R.id.dashboard_doubts -> changeToolbar(getString(R.string.dashboard), 3)
+            R.id.dashboard_doubts -> changeToolbar(getString(R.string.doubts), 3)
 
-            R.id.dashboard_library -> changeToolbar(getString(R.string.dashboard), 4)
+            R.id.dashboard_library -> changeToolbar(getString(R.string.library), 4)
         }
         dashboardDrawer.closeDrawer(GravityCompat.START)
         return true


### PR DESCRIPTION
Fixes #676 

Changes: The strings for my courses, doubts and library tabs are changed

Screenshots for the change:
![Record-2020-05-15-23-46-22](https://user-images.githubusercontent.com/34762451/82087185-36eb9800-970d-11ea-9d3d-634465696abf.gif)
