### PR TITLE
Feat: #689 Added a friendly message in My purchase page

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/purchases/PurchasesActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/purchases/PurchasesActivity.kt
@@ -1,6 +1,7 @@
 package com.codingblocks.cbonlineapp.purchases
 
 import android.os.Bundle
+import androidx.core.view.isVisible
 import com.codingblocks.cbonlineapp.R
 import com.codingblocks.cbonlineapp.baseclasses.BaseCBActivity
 import com.codingblocks.cbonlineapp.dashboard.DashboardViewModel
@@ -12,12 +13,11 @@ import com.codingblocks.cbonlineapp.util.extensions.setRv
 import com.codingblocks.cbonlineapp.util.extensions.setToolbar
 import kotlinx.android.synthetic.main.activity_purchases.*
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
-import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PurchasesActivity : BaseCBActivity() {
 
     private val viewModel: DashboardViewModel by stateViewModel()
-    private val courseListAdapter = MyCourseListAdapter()
+    private val courseListAdapter = MyCourseListAdapter("RUN")
 
     private val itemClickListener: ItemClickListener by lazy {
         object : ItemClickListener {
@@ -35,10 +35,16 @@ class PurchasesActivity : BaseCBActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_purchases)
         setToolbar(purchasesToolbar)
-        purchasedCoursesRv.setRv(this, courseListAdapter, true)
-        viewModel.purchasedRuns.observer(this) {
-            courseListAdapter.submitList(it)
-        }
-        courseListAdapter.onItemClick = itemClickListener
+            purchasedCoursesRv.setRv(this, courseListAdapter, true)
+            viewModel.purchasedRuns.observer(this) {list ->
+                courseListAdapter.submitList(list)
+                if(list.isNotEmpty())
+                {
+                    purchasedCoursesRv.isVisible = true
+                }
+            }
+            courseListAdapter.onItemClick = itemClickListener
+            purchasesMyCoursesExploreBtn.setOnClickListener { finish() }
+
     }
 }

--- a/app/src/main/res/layout/activity_purchases.xml
+++ b/app/src/main/res/layout/activity_purchases.xml
@@ -25,8 +25,30 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:overScrollMode="never"
-        android:visibility="visible"
+        android:visibility="gone"
         tools:itemCount="4"
         tools:listitem="@layout/item_courses" />
+    <TextView
+        android:id="@+id/emptyPurchaseText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="@dimen/nav_header_height"
+        android:layout_marginStart="@dimen/centre_container_l_vertical"
+        android:layout_marginEnd="@dimen/centre_container_l_vertical"
+        android:fontFamily="@font/gilroy_medium"
+        android:text="@string/your_courses_will_start_showing_once_you_purchase_any_course"
+        android:textAlignment="center"
+        android:textColor="@color/brownish_grey"
+        android:textSize="16sp" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/purchasesMyCoursesExploreBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/centre_container_l_vertical"
+        android:text="@string/explore_courses" />
+
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,7 @@
     <string name="username">Username</string>
     <string name="back">Back</string>
     <string name="your_courses_will_start_showing_once_you_enroll_nin_any_course">Your Courses will start showing once you enroll\nin any course</string>
+    <string name="your_courses_will_start_showing_once_you_purchase_any_course">Your Courses will start showing once you purchase any course</string>
     <string name="frequently_asked_questions">Frequently Asked Questions</string>
     <string name="student">Student</string>
     <string name="professional">Professional</string>
@@ -289,4 +290,5 @@
     <string name="payment_failed">Your payment has failed!</string>
     <string name="internet_connection_error">Please check your internet connection</string>
     <string name="retry">Retry Now</string>
+
 </resources>


### PR DESCRIPTION
Fixes #689 

Changes: Changes the blank screen of My purchases page with a friendly text and explore course button.

Screenshots for the change:

When no purchase is done:
![Screenshot_2020-05-17-00-53-33-45_7a48d95313daa0d8bdbf7891041c354f](https://user-images.githubusercontent.com/34762451/82128931-b09e8700-97dc-11ea-95f2-c69f77e246f8.png)

When purchase exists:
![Screenshot_2020-05-17-00-54-06-10_7a48d95313daa0d8bdbf7891041c354f](https://user-images.githubusercontent.com/34762451/82128935-bac08580-97dc-11ea-9da9-09b76b455e69.png)

