### PR TITLE
FIX-#769:  After logout you can still access profile using back button

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
@@ -62,4 +62,8 @@ class OnBoardingActivity : BaseCBActivity() {
         }
         dots[0].isSelected = true
     }
+
+    override fun onBackPressed() {
+        finishAffinity()
+    }
 }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
@@ -63,7 +63,5 @@ class OnBoardingActivity : BaseCBActivity() {
         dots[0].isSelected = true
     }
 
-    override fun onBackPressed() {
-        finishAffinity()
-    }
+
 }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/auth/onboarding/OnBoardingActivity.kt
@@ -63,5 +63,4 @@ class OnBoardingActivity : BaseCBActivity() {
         dots[0].isSelected = true
     }
 
-
 }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/profile/ProfileActivity.kt
@@ -178,7 +178,10 @@ class ProfileActivity : BaseCBActivity() {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                         })
                     }
+                    finishAffinity()
+
                 }
+
             }
         )
     }


### PR DESCRIPTION

Fixes #769

Changes: added the onBackPressed() method in OnBoardingActivity to resolve the issue where user can go back to profile dashboard by clicking on the backpress button and see his profile details even after he is logged out from the app.

Screenshots for the change:
![backPressedIssue](https://user-images.githubusercontent.com/38569124/82152738-fe6ccb00-9880-11ea-959a-07f3c0bbf3b9.png)

