### PR TITLE
fix: WhatsApp card displaying for empty link

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/overview/OverviewFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -148,16 +149,20 @@ class OverviewFragment : BaseCBFragment(), AnkoLogger {
     }
 
     private fun setWhatsappCard(link: String, premium: Boolean) {
-        whatsappContainer.apply {
-            isVisible = premium
-            setOnClickListener {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.setPackage("com.whatsapp")
-                intent.data = Uri.parse(link)
-                if (requireContext().packageManager.resolveActivity(intent, 0) != null) {
-                    startActivity(intent)
-                } else {
-                    Toast.makeText(requireContext(), "Please install whatsApp", Toast.LENGTH_SHORT).show()
+        if (link.isNullOrEmpty()) {
+            whatsappContainer.isVisible = false
+        } else {
+            whatsappContainer.apply {
+                isVisible = premium
+                setOnClickListener {
+                    val intent = Intent(Intent.ACTION_VIEW)
+                    intent.setPackage("com.whatsapp")
+                    intent.data = Uri.parse(link)
+                    if (requireContext().packageManager.resolveActivity(intent, 0) != null) {
+                        startActivity(intent)
+                    } else {
+                        Toast.makeText(requireContext(), "Please install whatsApp", Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/mycourse/overview/OverviewFragment.kt
@@ -85,7 +85,10 @@ class OverviewFragment : BaseCBFragment(), AnkoLogger {
                     }
                 }
             }
-            courseAndRun.run.whatsappLink?.let { setWhatsappCard(it, courseAndRun.runAttempt.premium) }
+            courseAndRun.run.whatsappLink?.let {
+                if(!it.isNullOrEmpty()){
+                setWhatsappCard(it, courseAndRun.runAttempt.premium)}
+            }
 
             if (courseAndRun.run.crStart > "1574985600") {
                 if (courseAndRun.run.crPrice > 10.toString() && courseAndRun.runAttempt.premium && RUNTIERS.LITE.name != courseAndRun.runAttempt.runTier)
@@ -149,9 +152,6 @@ class OverviewFragment : BaseCBFragment(), AnkoLogger {
     }
 
     private fun setWhatsappCard(link: String, premium: Boolean) {
-        if (link.isNullOrEmpty()) {
-            whatsappContainer.isVisible = false
-        } else {
             whatsappContainer.apply {
                 isVisible = premium
                 setOnClickListener {
@@ -165,7 +165,7 @@ class OverviewFragment : BaseCBFragment(), AnkoLogger {
                     }
                 }
             }
-        }
+
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Fixes #720 

Changes: I created an if else condition which checks whether the desired course has an intended 'WhatsApp Group' link, if the link is non empty or not null then only the 'WhatsApp Card to join Group' is displayed otherwise it does not. Hence you do not get the Toast Message saying "Please join WhatsApp". 
This ensures that the card is displayed only for those course which has 'WhatsApp Group' and an active link for joining it.


Screenshots for the change:
![Screenshot_20200519-035210](https://user-images.githubusercontent.com/61137052/82266102-61945580-9986-11ea-9a5f-156080f5eb83.png)

(for the same 'course' in the 'issue screenshot' the card was getting displayed, but in this no card is getting displayed because this course does not have a WhatsApp group)  
