### PR TITLE
Fix: #802 Back button from library toolbar fixed

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/library/LibraryActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/library/LibraryActivity.kt
@@ -19,6 +19,9 @@ class LibraryActivity : BaseCBActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_library)
         setToolbar(libraryToolbar)
+        libraryToolbar.setNavigationOnClickListener{
+            onBackPressed()
+        }
         intent.getStringExtra(COURSE_NAME)?.let {
             vm.name = it
         }


### PR DESCRIPTION
Fixes #802 

Changes: Made the toolbar back button to follow the onBackPressed method

Screenshots for the change:
![Record-2020-05-19-20-56-10-7a48d](https://user-images.githubusercontent.com/34762451/82346357-f8f3ba00-9a13-11ea-8614-3df49b6565fe.gif)
