### PR TITLE
fix: LinearLayout to properly display 'View all' 

### DIFF
--- a/app/src/main/res/layout/fragment_dashboard_explore.xml
+++ b/app/src/main/res/layout/fragment_dashboard_explore.xml
@@ -140,9 +140,9 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_medium_small"
                 android:layout_marginTop="@dimen/margin_large"
-                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_medium_small"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
@@ -231,9 +231,9 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_medium_small"
                 android:layout_marginTop="@dimen/margin_large"
-                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_medium_small"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 


### PR DESCRIPTION
Fixes #779 

Changes: I changed the margin of the two Linear Layouts of both 'Learning Tracks' and 'Trending Now' to properly space out things, so that full 'View all' text and the drawable is visible and displayed. 

Screenshots for the change:
![Screenshot_20200520-012753](https://user-images.githubusercontent.com/61137052/82373076-a7125a80-9a3a-11ea-8c90-881f2d05304f.png)

(as you can see now the View all text is properly displayed in both the layouts)'
