### PR TITLE
Used Space Progress issue fixed

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
@@ -99,7 +99,8 @@ class SettingsActivity : BaseCBActivity() {
                 it
             ).readableFileSize()
         })
-        val usedSpace : Double = file?.let { folderSize(it) }!!.toDouble() / 1048576
+
+        val usedSpace : Double = ((file?.let { folderSize(it) }?.toDouble()?.div(1048576) ?: 0.0))
         Log.v("usedSpace","Used Space is $usedSpace")
         storageProgress.max = bytesAvailable.toInt() / 1048576
         storageProgress.progress = usedSpace.toInt()

--- a/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
@@ -3,16 +3,13 @@ package com.codingblocks.cbonlineapp.settings
 import android.os.Bundle
 import android.os.Environment
 import android.os.StatFs
+import android.util.Log
 import android.widget.SeekBar
 import androidx.lifecycle.lifecycleScope
 import com.codingblocks.cbonlineapp.R
 import com.codingblocks.cbonlineapp.baseclasses.BaseCBActivity
 import com.codingblocks.cbonlineapp.util.MediaUtils
-import com.codingblocks.cbonlineapp.util.extensions.folderSize
-import com.codingblocks.cbonlineapp.util.extensions.getPrefs
-import com.codingblocks.cbonlineapp.util.extensions.readableFileSize
-import com.codingblocks.cbonlineapp.util.extensions.setToolbar
-import com.codingblocks.cbonlineapp.util.extensions.showDialog
+import com.codingblocks.cbonlineapp.util.extensions.*
 import java.io.File
 import kotlinx.android.synthetic.main.activity_settings.*
 import kotlinx.coroutines.Dispatchers
@@ -102,6 +99,10 @@ class SettingsActivity : BaseCBActivity() {
                 it
             ).readableFileSize()
         })
+        val usedSpace : Double = file?.let { folderSize(it) }!!.toDouble() / 1048576
+        Log.v("usedSpace","Used Space is $usedSpace")
+        storageProgress.max = bytesAvailable.toInt() / 1048576
+        storageProgress.progress = usedSpace.toInt()
     }
 
     private fun setSeekbarProgress(progress: Int) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -86,6 +86,7 @@
             android:text="Available Storage" />
 
         <ProgressBar
+            android:id="@+id/storageProgress"
             style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #696 

Progress Bar was not showing the space used after downloading the videos from the courses. But now its fixed and I have tested it on 3 different devices. Its working awesome :)

Screenshots for the change:
![Screenshot_2020-06-05-18-14-09-25](https://user-images.githubusercontent.com/36165541/83878142-4f256480-a759-11ea-8034-5663c3cb3e1e.png)
