### PR TITLE
Adding support for external SD Card

### DIFF
--- a/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/settings/SettingsActivity.kt
@@ -5,6 +5,7 @@ import android.os.Environment
 import android.os.StatFs
 import android.util.Log
 import android.widget.SeekBar
+import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import com.codingblocks.cbonlineapp.R
 import com.codingblocks.cbonlineapp.baseclasses.BaseCBActivity
@@ -22,7 +23,11 @@ class SettingsActivity : BaseCBActivity() {
     private val viewModel by viewModel<SettingsViewModel>()
 
     private val file by lazy {
-        this.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+        if (getPrefs().SP_SD_CARD && checkExternalDirectory()) {
+            this.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)[1]
+        } else {
+            this.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+        }
     }
 
     private val stat by lazy { StatFs(Environment.getExternalStorageDirectory().path) }
@@ -89,6 +94,30 @@ class SettingsActivity : BaseCBActivity() {
         pipSwitch.setOnClickListener {
             getPrefs().SP_PIP = pipSwitch.isChecked
         }
+        sdcardSwitch.isChecked = checkExternalDirectory() && getPrefs().SP_SD_CARD
+        sdcardSwitch.setOnClickListener {
+            updateSdCardSwitch()
+        }
+    }
+
+    private fun updateSdCardSwitch() {
+        if (sdcardSwitch.isChecked) {
+            if (checkExternalDirectory()) {
+                getPrefs().SP_SD_CARD = true
+            } else {
+                Toast.makeText(this, "No External SD Card found.", Toast.LENGTH_LONG).show()
+                sdcardSwitch.performClick()
+            }
+        } else {
+            getPrefs().SP_SD_CARD = false
+        }
+    }
+
+    private fun checkExternalDirectory(): Boolean {
+        val directories = applicationContext.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)
+        if (directories.size > 1)
+            return true
+        return false
     }
 
     private fun updateSpaceStats() {

--- a/app/src/main/java/com/codingblocks/cbonlineapp/util/FileUtils.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/util/FileUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Environment
 import android.util.Log
 import com.codingblocks.cbonlineapp.settings.SettingsActivity
+import com.codingblocks.cbonlineapp.util.PreferenceHelper.Companion.getPrefs
 import com.codingblocks.cbonlineapp.util.extensions.folderSize
 import com.codingblocks.cbonlineapp.util.extensions.getPrefs
 import org.jetbrains.anko.intentFor
@@ -18,7 +19,11 @@ const val GB_TO_KB = 1024 * 1024
 object FileUtils {
 
     private fun getCommonPath(context: Context) =
-        context.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+        if (getPrefs(context).SP_SD_CARD) {
+            context.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)[1]
+        } else{
+            context.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+        }
 
     fun deleteDatabaseFile(context: Context, databaseName: String) {
         val databases = File(context.applicationInfo.dataDir + "/databases")

--- a/app/src/main/java/com/codingblocks/cbonlineapp/util/PreferenceHelper.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/util/PreferenceHelper.kt
@@ -103,6 +103,12 @@ class PreferenceHelper private constructor() {
             prefs?.save("COURSE_FILTER_TYPE", value)
         }
 
+    var SP_SD_CARD: Boolean
+        get() = prefs?.getBoolean("SD_CARD", false) ?: false
+        set(value) {
+            prefs?.save("SD_CARD", value)
+        }
+
     fun clearPrefs() {
         prefs?.edit()?.clear()?.apply()
     }

--- a/app/src/main/java/com/codingblocks/cbonlineapp/workers/DownloadService.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/workers/DownloadService.kt
@@ -15,13 +15,7 @@ import com.codingblocks.cbonlineapp.database.ContentDao
 import com.codingblocks.cbonlineapp.database.models.ContentModel
 import com.codingblocks.cbonlineapp.database.models.DownloadData
 import com.codingblocks.cbonlineapp.mycourse.content.player.VideoPlayerActivity
-import com.codingblocks.cbonlineapp.util.CONTENT_ID
-import com.codingblocks.cbonlineapp.util.DOWNLOAD_CHANNEL_ID
-import com.codingblocks.cbonlineapp.util.FileUtils
-import com.codingblocks.cbonlineapp.util.RUN_ATTEMPT_ID
-import com.codingblocks.cbonlineapp.util.SECTION_ID
-import com.codingblocks.cbonlineapp.util.TITLE
-import com.codingblocks.cbonlineapp.util.VIDEO_ID
+import com.codingblocks.cbonlineapp.util.*
 import com.codingblocks.onlineapi.CBOnlineLib
 import com.google.gson.JsonObject
 import com.vdocipher.aegis.media.ErrorDescription
@@ -149,7 +143,15 @@ class DownloadService : Service(), VdoDownloadManager.EventListener {
                     // we have received the available download options
                     val selectionIndices = intArrayOf(0, 1)
                     val downloadSelections = DownloadSelections(options, selectionIndices)
-                    val file = applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    var file = applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    val directories =
+                        applicationContext.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)
+                    if (PreferenceHelper.getPrefs(applicationContext).SP_SD_CARD && directories.size > 1) {
+                        file = directories[1]
+                    }else {
+                        PreferenceHelper.getPrefs(applicationContext).SP_SD_CARD = false
+                    }
+
                     val folderFile = File(file, "/$videoId")
                     if (!folderFile.exists()) {
                         folderFile.mkdir()

--- a/app/src/main/java/com/codingblocks/cbonlineapp/workers/DownloadWorker.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/workers/DownloadWorker.kt
@@ -21,6 +21,7 @@ import com.codingblocks.cbonlineapp.util.RUN_ATTEMPT_ID
 import com.codingblocks.cbonlineapp.util.SECTION_ID
 import com.codingblocks.cbonlineapp.util.TITLE
 import com.codingblocks.cbonlineapp.util.VIDEO_ID
+import com.codingblocks.cbonlineapp.util.PreferenceHelper.Companion.getPrefs
 import com.codingblocks.onlineapi.CBOnlineLib
 import com.google.gson.JsonObject
 import com.vdocipher.aegis.media.ErrorDescription
@@ -112,8 +113,14 @@ class DownloadWorker(context: Context, private val workerParameters: WorkerParam
                     // we have received the available download options
                     val selectionIndices = intArrayOf(0, 1)
                     val downloadSelections = DownloadSelections(options, selectionIndices)
-                    val file =
-                        applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    var file = applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    val directories =
+                        applicationContext.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)
+                    if (getPrefs(applicationContext).SP_SD_CARD && directories.size > 1) {
+                        file = directories[1]
+                    }else {
+                        getPrefs(applicationContext).SP_SD_CARD = false
+                    }
                     val folderFile = File(file, "/$videoId")
                     if (!folderFile.exists()) {
                         folderFile.mkdir()

--- a/app/src/main/java/com/codingblocks/cbonlineapp/workers/SectionDownloadService.kt
+++ b/app/src/main/java/com/codingblocks/cbonlineapp/workers/SectionDownloadService.kt
@@ -16,10 +16,7 @@ import com.codingblocks.cbonlineapp.database.ContentDao
 import com.codingblocks.cbonlineapp.database.SectionWithContentsDao
 import com.codingblocks.cbonlineapp.database.models.ContentModel
 import com.codingblocks.cbonlineapp.database.models.SectionContentHolder
-import com.codingblocks.cbonlineapp.util.DOWNLOAD_CHANNEL_ID
-import com.codingblocks.cbonlineapp.util.FileUtils
-import com.codingblocks.cbonlineapp.util.RUN_ATTEMPT_ID
-import com.codingblocks.cbonlineapp.util.SECTION_ID
+import com.codingblocks.cbonlineapp.util.*
 import com.codingblocks.onlineapi.CBOnlineLib
 import com.google.gson.JsonObject
 import com.vdocipher.aegis.media.ErrorDescription
@@ -145,7 +142,14 @@ class SectionDownloadService : Service(), VdoDownloadManager.EventListener {
                     // we have received the available download options
                     val selectionIndices = intArrayOf(0, 1)
                     val downloadSelections = DownloadSelections(options, selectionIndices)
-                    val file = applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    var file = applicationContext.getExternalFilesDir(Environment.getDataDirectory().absolutePath)
+                    val directories =
+                        applicationContext.getExternalFilesDirs(Environment.getDataDirectory().absolutePath)
+                    if (PreferenceHelper.getPrefs(applicationContext).SP_SD_CARD && directories.size > 1) {
+                        file = directories[1]
+                    }else {
+                        PreferenceHelper.getPrefs(applicationContext).SP_SD_CARD = false
+                    }
                     val folderFile = File(file, "/$videoId")
                     if (!folderFile.exists()) {
                         folderFile.mkdir()

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -62,6 +62,23 @@
             android:layout_marginBottom="16dp"
             android:background="#eeeeee" />
 
+        <Switch
+            android:id="@+id/sdcardSwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/ripple"
+            android:fontFamily="@font/gilroy_bold"
+            android:text="Save downloads to SD Card"
+            android:textSize="18sp"
+            app:theme="@style/ColorSwitchStyle"></Switch>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:background="#eeeeee" />
+
         <TextView
             android:id="@+id/deleteAllTv"
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #866 

Changes:
Added share preference to store SD Card switch data.
Checks for external storage.The first storage returned by getExternalFilesDirs() is Internal memory and second is external SD Card if present.

Screenshots for the change:
![20200813_163847](https://user-images.githubusercontent.com/18425237/90169532-5356a980-ddbc-11ea-97ef-367b252a3384.gif)
